### PR TITLE
Upgrade go and specify image variant

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.20.5
+    tag: 1.20.6-bullseye
 
 inputs:
   - name: dp-search-reindex-batch

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.20.5
+    tag: 1.20.6-bullseye
 
 inputs:
   - name: dp-search-reindex-batch

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.20.5
+    tag: 1.20.6-bullseye
 
 inputs:
   - name: dp-search-reindex-batch


### PR DESCRIPTION
### What

Upgraded the go build image and specified a specific variant to fix runtime GLIB errors due to changed underlying debian version of golang image 1.20.5+

### How to review

Ensure tests pass and code makes sense.

### Who can review

Anyone but me