### PR TITLE
Increase zebedee timeout

### DIFF
--- a/task/reindex.go
+++ b/task/reindex.go
@@ -84,7 +84,7 @@ func reindex(ctx context.Context) error {
 		panic(err)
 	}
 	hcClienter.SetMaxRetries(2)
-	hcClienter.SetTimeout(30 * time.Second) // Published Index takes about 10s to return so add a bit more
+	hcClienter.SetTimeout(2 * time.Minute) // Published Index takes about 10s to return (>1m in sandbox) so add a bit more
 
 	zebClient := zebedee.NewClientWithClienter(cfg.zebedeeURL, hcClienter)
 	if !cfg.IgnoreZebedee && zebClient == nil {


### PR DESCRIPTION
### What

Increased the zebedee client timeout due to full index taking >1min in sandbox. In future this should be improved via paged or asynchronous requests instead (when implemented in zebedee).

### How to review

Ensure tests pass and code makes sense.

### Who can review

Anyone but me