### PR TITLE
Fix broken concurrency in reindexer

### DIFF
--- a/task/reindex_test.go
+++ b/task/reindex_test.go
@@ -79,7 +79,8 @@ func TestTransformMetadataDoc(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 			go func(waitGroup *sync.WaitGroup) {
-				transformMetadataDoc(ctx, metadataChan, transformedChan, waitGroup)
+				transformMetadataDoc(ctx, metadataChan, transformedChan)
+				wg.Done()
 			}(wg)
 
 			Convey("Then the expected elasticsearch document is sent to the transformed channel", func() {
@@ -151,7 +152,8 @@ func TestTransformMetadataDoc(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 			go func(waitGroup *sync.WaitGroup) {
-				transformMetadataDoc(ctx, metadataChan, transformedChan, waitGroup)
+				transformMetadataDoc(ctx, metadataChan, transformedChan)
+				wg.Done()
 			}(wg)
 
 			Convey("Then the expected elasticsearch document is sent to the transformed channel", func() {


### PR DESCRIPTION
### What

Fix issues with concurrency

- Invalid use of goroutines, causing uncontrolled scaling out of doc transformers etc.
- Removed serial processing of doc/metadata transformation; now split into separate processors with a subsequent joining of the channels instead
- Removed unecessary multiple doc indexers (it uses a bulk indexer anyway, so one process is enough).

Note, I'm doing the minimal of changes in small PRs so not everything is perfect with the resulting code, it's just an incremental improvement on what was there before. There'll be other PRs to follow for things like error handling etc.

### How to review

Check code makes sense (happy to explain) and that tests etc. pass.

### Who can review

Anyone but me