### PR TITLE
Stop old timeseries being indexed

### DIFF
--- a/task/reindex.go
+++ b/task/reindex.go
@@ -154,8 +154,10 @@ func uriProducer(ctx context.Context, tracker *Tracker, errorChan chan error, z 
 			return
 		}
 		for _, item := range items {
-			uriChan <- item.URI
-			tracker.Inc("uri")
+			if !strings.Contains(item.URI, "/timeseries/") && !strings.Contains(item.URI, "/previous/") {
+				uriChan <- item.URI
+				tracker.Inc("uri")
+			}
 		}
 		log.Info(ctx, "finished listing uris")
 	}()


### PR DESCRIPTION
### What

Stop old timeseries (e.g. /economy/inflationandpriceindices/timeseries/chaw/mm23/previous/v108) being indexed - I've done this at the fetch URI stage to prevent further calls to zebedee

### How to review

Run it and see that it works!

### Who can review

Not me. 