### PR TITLE
Add zebedee timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Batch nomad job for reindexing search
 | TOPIC_API_URL               | "http://localhost:25300" | URL of the Topic API                                                       |
 | TRACKER_INTERVAL            | 5s                       | Interval for progress tracker summary logging                              |
 | ZEBEDEE_URL                 | "http://localhost:8082"  | URL of publishing zebedee                                                  |
+| ZEBEDEE_TIMEOUT             | 2m                       | Timeout for Zebedee endpoints - published index can take > 2 minutes       |
 
 ### Local Prerequisites
 

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	TopicTaggingEnabled    bool          `envconfig:"ENABLE_TOPIC_TAGGING"`
 	TrackerInterval        time.Duration `envconfig:"TRACKER_INTERVAL"`
 	ZebedeeURL             string        `envconfig:"ZEBEDEE_URL"`
+	ZebedeeTimeout         time.Duration `envconfig:"ZEBEDEE_TIMEOUT"`
 }
 
 var cfg *Config
@@ -36,6 +37,7 @@ func Get() (*Config, error) {
 
 	cfg = &Config{
 		ZebedeeURL:             "http://localhost:8082",
+		ZebedeeTimeout:         2 * time.Minute,
 		ElasticSearchURL:       "http://localhost:11200",
 		SignESRequests:         false,
 		AwsRegion:              "eu-west-2",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,6 +38,7 @@ func TestConfig(t *testing.T) {
 					TrackerInterval:        5000 * time.Millisecond,
 					TopicAPIURL:            "http://localhost:25300",
 					TopicTaggingEnabled:    false,
+					ZebedeeTimeout:         2 * time.Minute,
 				},
 				)
 			})

--- a/task/reindex.go
+++ b/task/reindex.go
@@ -56,7 +56,7 @@ func reindex(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 	hcClienter.SetMaxRetries(2)
-	hcClienter.SetTimeout(2 * time.Minute) // Published Index takes about 10s to return (>1m in sandbox) so add a bit more
+	hcClienter.SetTimeout(cfg.ZebedeeTimeout)
 
 	zebClient := zebedee.NewClientWithClienter(cfg.ZebedeeURL, hcClienter)
 	if zebClient == nil {


### PR DESCRIPTION
### What

Added ZEBEDEE_TIMEOUT to control the timeout for zebedee's publishedindex endpoint which can be very slow. 

### How to review

Check looks ok, see that it can be configured. 

### Who can review

Not me. 