### PR TITLE
Fix/upstream config

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,0 +1,1 @@
+CVE-2025-4673 # Ignored due to golang.org/x/net v0.41.0 being the latest release

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 ONS Digital
+Copyright (c) 2025 ONS Digital
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Batch nomad job for reindexing search
 
-### Getting started
+## Getting started
 
 * Run `make debug` to run application (See [Local Prerequisites section](#local-prerequisites) first)
 * Run `make help` to see full list of make targets
@@ -13,28 +13,72 @@ Batch nomad job for reindexing search
 
 ### Configuration
 
-| Environment variable          | Default                                    | Description                                                                                    |
-|-------------------------------|--------------------------------------------|------------------------------------------------------------------------------------------------|
-| AWS_REGION                    | "eu-west-2"                                | AWS region                                                                                     |
-| AWS_SEC_SKIP_VERIFY           | false                                      | Whether to skip TLS verification for AWS requests                                              |
-| DATASET_API_URL               | "http://localhost:22000"                   | URL of the Dataset API                                                                         |
-| DATASET_PAGINATION_LIMIT      | 500                                        | Number of datasets to fetch per page of requests to Dataset API                                |
-| ELASTIC_SEARCH_URL            | "http://localhost:11200"                   | URL of elastic search server (or AWS Opensearch)                                               |
-| ENABLE_DATASET_API_REINDEX    | false                                      | Whether to get documents from the Dataset API for reindexing or not                            |
-| ENABLE_OTHER_SERVICES_REINDEX | false                                      | Whether to get documents from other upstream services or not                                   |
-| ENABLE_TOPIC_TAGGING          | false                                      | Whether to enable topic auto-tagging                                                           |
-| ENABLE_ZEBEDEE_REINDEX        | false                                      | Whether to get documents from Zebedee for reindexing or not                                    |
-| MAX_DATASET_EXTRACTIONS       | 20                                         | Max number of concurrent Dataset Extractions (ie. Dataset API connections)                     |
-| MAX_DATASET_TRANSFORMS        | 10                                         | Max number of concurrent Dataset Transformation workers                                        |
-| MAX_DOCUMENT_EXTRACTIONS      | 100                                        | Max number of concurrent Document Extractions (ie. Zebedee connections)                        |
-| MAX_DOCUMENT_TRANSFORMS       | 20                                         | Max number of concurrent Document Transformation workers                                       |
-| OTHER_UPSTREAM_SERVICES       | [["http://localhost:29600", "/resources"]] | List of string pairs, each consisting of a domain and endpoint, representing upstream services |
-| SERVICE_AUTH_TOKEN            | ""                                         | Zebedee Service Auth Token for API requests                                                    |
-| SIGN_ELASTICSEARCH_REQUESTS   | false                                      | Whether to sign elasticsearch requests (true for AWS)                                          |
-| TOPIC_API_URL                 | "http://localhost:25300"                   | URL of the Topic API                                                                           |
-| TRACKER_INTERVAL              | 5s                                         | Interval for progress tracker summary logging                                                  |
-| ZEBEDEE_TIMEOUT               | 2m                                         | Timeout for Zebedee endpoints - published index can take > 2 minutes                           |
-| ZEBEDEE_URL                   | "http://localhost:8082"                    | URL of publishing zebedee                                                                      |
+| Environment variable          | Default                                                        | Description                                                                |
+|-------------------------------|----------------------------------------------------------------|----------------------------------------------------------------------------|
+| AWS_REGION                    | "eu-west-2"                                                    | AWS region                                                                 |
+| AWS_SEC_SKIP_VERIFY           | false                                                          | Whether to skip TLS verification for AWS requests                          |
+| DATASET_API_URL               | "<http://localhost:22000>"                                     | URL of the Dataset API                                                     |
+| DATASET_PAGINATION_LIMIT      | 500                                                            | Number of datasets to fetch per page of requests to Dataset API            |
+| ELASTIC_SEARCH_URL            | "<http://localhost:11200>"                                     | URL of elastic search server (or AWS Opensearch)                           |
+| ENABLE_DATASET_API_REINDEX    | false                                                          | Whether to get documents from the Dataset API for reindexing or not        |
+| ENABLE_OTHER_SERVICES_REINDEX | false                                                          | Whether to get documents from other upstream services or not               |
+| ENABLE_TOPIC_TAGGING          | false                                                          | Whether to enable topic auto-tagging                                       |
+| ENABLE_ZEBEDEE_REINDEX        | false                                                          | Whether to get documents from Zebedee for reindexing or not                |
+| MAX_DATASET_EXTRACTIONS       | 20                                                             | Max number of concurrent Dataset Extractions (ie. Dataset API connections) |
+| MAX_DATASET_TRANSFORMS        | 10                                                             | Max number of concurrent Dataset Transformation workers                    |
+| MAX_DOCUMENT_EXTRACTIONS      | 100                                                            | Max number of concurrent Document Extractions (ie. Zebedee connections)    |
+| MAX_DOCUMENT_TRANSFORMS       | 20                                                             | Max number of concurrent Document Transformation workers                   |
+| OTHER_UPSTREAM_SERVICES       | [["http://localhost:29600", "/resources"]]                     | List of upstream services. Each consisting a host and an endpoint. (See [other_upstream_services](#other_upstream_services))     |
+| SERVICE_AUTH_TOKEN            | ""                                                             | Zebedee Service Auth Token for API requests                                |
+| SIGN_ELASTICSEARCH_REQUESTS   | false                                                          | Whether to sign elasticsearch requests (true for AWS)                      |
+| TOPIC_API_URL                 | "<http://localhost:25300>"                                     | URL of the Topic API                                                       |
+| TRACKER_INTERVAL              | 5s                                                             | Interval for progress tracker summary logging                              |
+| ZEBEDEE_TIMEOUT               | 2m                                                             | Timeout for Zebedee endpoints - published index can take > 2 minutes       |
+| ZEBEDEE_URL                   | "<http://localhost:8082>"                                      | URL of publishing zebedee                                                  |
+
+#### OTHER_UPSTREAM_SERVICES
+
+The variable for OTHER_UPSTREAM_SERVICES consist of a array of array with the following schema
+
+```yaml
+OTHER_UPSTREAM_SERVICES:
+    type: array
+    description: "An array of other upstream services"
+    items:
+        type: array
+        description: >
+            An individual upstream service consisting of two strings,
+            a host and an endpoint
+        items:
+            type: string
+            maxItems: 2
+        example: ["localhost:29600", "/resources1"]
+```
+
+For example:
+
+```json
+[
+    [
+        "http://localhost29600",
+        "/resources"
+    ]
+]
+```
+
+This would then be provided as an environment variable like so:
+
+```sh
+export OTHER_UPSTREAM_SERVICES='[["http://localhost:29600","/resources"]]'
+```
+
+For the purposes of our configuration this would need to be double escaped like so:
+
+```json
+// ...json
+"OTHER_UPSTREAM_SERVICES":"[[\\\"http://localhost:29600\\\", \\\"/resources/\\\"]]"
+// ...more json
+```
 
 ### Local Prerequisites
 
@@ -77,7 +121,6 @@ See [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ### License
 
-Copyright © 2023, Office for National Statistics (https://www.ons.gov.uk)
+Copyright © 2025, Office for National Statistics (<https://www.ons.gov.uk>)
 
 Released under MIT license, see [LICENSE](LICENSE.md) for details.
-

--- a/config/config.go
+++ b/config/config.go
@@ -1,33 +1,68 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
 )
 
+type UpStreamServices []UpStreamService
+
+type UpStreamService struct {
+	Host     string
+	Endpoint string
+}
+
+func (u *UpStreamServices) UnmarshalText(text []byte) error {
+	var services [][]string
+
+	err := json.Unmarshal(text, &services)
+	if err != nil {
+		return err
+	}
+
+	*u = nil
+
+	for _, serviceData := range services {
+		if len(serviceData) == 2 {
+			service := UpStreamService{
+				Host:     serviceData[0],
+				Endpoint: serviceData[1],
+			}
+
+			*u = append(*u, service)
+		} else {
+			return fmt.Errorf("service data provided did not match expected")
+		}
+	}
+
+	return nil
+}
+
 // Config represents service configuration for dp-search-reindex-batch
 type Config struct {
-	AwsRegion                  string        `envconfig:"AWS_REGION"`
-	AwsSecSkipVerify           bool          `envconfig:"AWS_SEC_SKIP_VERIFY"`
-	DatasetAPIURL              string        `envconfig:"DATASET_API_URL"`
-	ElasticSearchURL           string        `envconfig:"ELASTIC_SEARCH_URL"`
-	EnableDatasetAPIReindex    bool          `envconfig:"ENABLE_DATASET_API_REINDEX"`
-	EnableOtherServicesReindex bool          `envconfig:"ENABLE_OTHER_SERVICES_REINDEX"`
-	EnableZebedeeReindex       bool          `envconfig:"ENABLE_ZEBEDEE_REINDEX"`
-	MaxDatasetExtractions      int           `envconfig:"MAX_DATASET_EXTRACTIONS"`
-	MaxDatasetTransforms       int           `envconfig:"MAX_DATASET_TRANSFORMS"`
-	MaxDocumentExtractions     int           `envconfig:"MAX_DOCUMENT_EXTRACTIONS"`
-	MaxDocumentTransforms      int           `envconfig:"MAX_DOCUMENT_TRANSFORMS"`
-	OtherUpstreamServices      [][]string    `envconfig:"OTHER_UPSTREAM_SERVICES"`
-	PaginationLimit            int           `envconfig:"DATASET_PAGINATION_LIMIT"`
-	ServiceAuthToken           string        `envconfig:"SERVICE_AUTH_TOKEN"             json:"-"`
-	SignESRequests             bool          `envconfig:"SIGN_ELASTICSEARCH_REQUESTS"`
-	TopicAPIURL                string        `envconfig:"TOPIC_API_URL"`
-	TopicTaggingEnabled        bool          `envconfig:"ENABLE_TOPIC_TAGGING"`
-	TrackerInterval            time.Duration `envconfig:"TRACKER_INTERVAL"`
-	ZebedeeTimeout             time.Duration `envconfig:"ZEBEDEE_TIMEOUT"`
-	ZebedeeURL                 string        `envconfig:"ZEBEDEE_URL"`
+	AwsRegion                  string           `envconfig:"AWS_REGION"`
+	AwsSecSkipVerify           bool             `envconfig:"AWS_SEC_SKIP_VERIFY"`
+	DatasetAPIURL              string           `envconfig:"DATASET_API_URL"`
+	ElasticSearchURL           string           `envconfig:"ELASTIC_SEARCH_URL"`
+	EnableDatasetAPIReindex    bool             `envconfig:"ENABLE_DATASET_API_REINDEX"`
+	EnableOtherServicesReindex bool             `envconfig:"ENABLE_OTHER_SERVICES_REINDEX"`
+	EnableZebedeeReindex       bool             `envconfig:"ENABLE_ZEBEDEE_REINDEX"`
+	MaxDatasetExtractions      int              `envconfig:"MAX_DATASET_EXTRACTIONS"`
+	MaxDatasetTransforms       int              `envconfig:"MAX_DATASET_TRANSFORMS"`
+	MaxDocumentExtractions     int              `envconfig:"MAX_DOCUMENT_EXTRACTIONS"`
+	MaxDocumentTransforms      int              `envconfig:"MAX_DOCUMENT_TRANSFORMS"`
+	OtherUpstreamServices      UpStreamServices `envconfig:"OTHER_UPSTREAM_SERVICES"`
+	PaginationLimit            int              `envconfig:"DATASET_PAGINATION_LIMIT"`
+	ServiceAuthToken           string           `envconfig:"SERVICE_AUTH_TOKEN"             json:"-"`
+	SignESRequests             bool             `envconfig:"SIGN_ELASTICSEARCH_REQUESTS"`
+	TopicAPIURL                string           `envconfig:"TOPIC_API_URL"`
+	TopicTaggingEnabled        bool             `envconfig:"ENABLE_TOPIC_TAGGING"`
+	TrackerInterval            time.Duration    `envconfig:"TRACKER_INTERVAL"`
+	ZebedeeTimeout             time.Duration    `envconfig:"ZEBEDEE_TIMEOUT"`
+	ZebedeeURL                 string           `envconfig:"ZEBEDEE_URL"`
 }
 
 var cfg *Config
@@ -51,15 +86,20 @@ func Get() (*Config, error) {
 		MaxDatasetTransforms:       10,
 		MaxDocumentExtractions:     100,
 		MaxDocumentTransforms:      20,
-		OtherUpstreamServices:      [][]string{{"http://localhost:29600", "/resources"}},
-		PaginationLimit:            500,
-		ServiceAuthToken:           "",
-		SignESRequests:             false,
-		TopicAPIURL:                "http://localhost:25300",
-		TopicTaggingEnabled:        false,
-		TrackerInterval:            5 * time.Second,
-		ZebedeeTimeout:             2 * time.Minute,
-		ZebedeeURL:                 "http://localhost:8082",
+		OtherUpstreamServices: UpStreamServices{
+			UpStreamService{
+				Host:     "http://localhost:29600",
+				Endpoint: "/resources",
+			},
+		},
+		PaginationLimit:     500,
+		ServiceAuthToken:    "",
+		SignESRequests:      false,
+		TopicAPIURL:         "http://localhost:25300",
+		TopicTaggingEnabled: false,
+		TrackerInterval:     5 * time.Second,
+		ZebedeeTimeout:      3 * time.Minute,
+		ZebedeeURL:          "http://localhost:8082",
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,10 +38,15 @@ func TestConfig(t *testing.T) {
 					TrackerInterval:         5000 * time.Millisecond,
 					TopicAPIURL:             "http://localhost:25300",
 					TopicTaggingEnabled:     false,
-					ZebedeeTimeout:          2 * time.Minute,
+					ZebedeeTimeout:          3 * time.Minute,
 					EnableDatasetAPIReindex: false,
 					EnableZebedeeReindex:    false,
-					OtherUpstreamServices:   [][]string{{"http://localhost:29600", "/resources"}},
+					OtherUpstreamServices: UpStreamServices{
+						UpStreamService{
+							Host:     "http://localhost:29600",
+							Endpoint: "/resources",
+						},
+					},
 				},
 				)
 			})

--- a/task/reindex.go
+++ b/task/reindex.go
@@ -109,12 +109,10 @@ func reindex(ctx context.Context, cfg *config.Config) error {
 	numUpstreamServices := len(cfg.OtherUpstreamServices)
 	upstreamServiceClients := make([]*upstreamStubSDK.Client, numUpstreamServices)
 
-	for i := 0; i < numUpstreamServices; i++ {
-		serviceURL := cfg.OtherUpstreamServices[i][0]
-		serviceEndpoint := cfg.OtherUpstreamServices[i][1]
-		upstreamStubClient := upstreamStubSDK.New(serviceURL, serviceEndpoint)
+	for i, upstreamService := range cfg.OtherUpstreamServices {
+		upstreamStubClient := upstreamStubSDK.New(upstreamService.Host, upstreamService.Endpoint)
 		if upstreamStubClient == nil {
-			err := errors.New("failed to create client for upstream service: " + serviceURL + serviceEndpoint)
+			err := errors.New("failed to create client for upstream service: " + upstreamService.Host + upstreamService.Endpoint)
 			log.Error(ctx, err.Error(), err)
 			return err
 		}


### PR DESCRIPTION
### What

- Out of bound error when creating new client endpoint pair from `OTHER_UPSTREAM_SERVICES` envconfig values 

### How to review

- Run dependencies
  - Run `make start` in `dp-compose` dir

- Try in develop branch
  - `export OTHER_UPSTREAM_SERVICES='[["http://localhost:29700","/resources"]]'`
  - Run `make debug`
  - This will fail and raise a panic error
- Switch to PR branch
  - Run `make debug`
  - You should see a success message

### Who can review

!Me
